### PR TITLE
Promises/A+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   ],
   "dependencies": {
     "async": "~0.2.5",
-    "underscore": "~1.4.4",
     "coffee-script": "~1.6.0",
-    "underscore.string": "~2.3.1",
     "dotty": "0.0.1",
+    "q": "^1.4.1",
     "quest": "~0.2.4",
     "readable-stream": "~1.0.2",
-    "underscore.deep": "~0.5.1"
+    "underscore": "~1.4.4",
+    "underscore.deep": "~0.5.1",
+    "underscore.string": "~2.3.1"
   },
   "devDependencies": {
     "mocha": "~1.7.4",


### PR DESCRIPTION
Allows developers to interact with the library using promise syntax.

Example:

``` javascript
return clever.District.findOne({}).exec().then(function(district) {
  return clever.School.find({district: district.get('id')}).exec();
}, function(err) {
  console.error('An error occurred obtaining a district.', err);
});
```
